### PR TITLE
Use eval in global scope

### DIFF
--- a/Resources/Public/JavaScript/cookie.js
+++ b/Resources/Public/JavaScript/cookie.js
@@ -58,7 +58,7 @@ window.addEventListener("load", function () {
             /** run Code it something in in it **/
             if(code.length) {
                 /** if Is Code Eval Code **/
-                eval(code);
+                eval.call(this,code);
             } else {
                 /** If is SRC load that **/
                 var element = elements[key];


### PR DESCRIPTION
Only global scope can read a global variable like _paq from Matomo.
More about the problem here: http://perfectionkills.com/global-eval-what-are-the-options/