### PR TITLE
Add support for v10.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "GPL-3.0-or-later"
   ],
   "require": {
-    "typo3/cms-core": "~6.2.0||~7.6.0||~8.7.0||~9.5.0||~10.0.0||dev-master"
+    "typo3/cms-core": "~6.2.0||~7.6.0||~8.7.0||~9.5.0||~10.4.0||dev-master"
   },
   "replace": {
     "typo3-ter/dp_cookieconsent": "self.version"


### PR DESCRIPTION
Hey @DirkPersky ,

first of all, thanks for this package! 

I updated the version constraint for TYPO3, so that v10.4 is also allowed. 

Cheers
Markus