### PR TITLE
#55 Add v11 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "AGPL-3.0-or-later"
   ],
   "require": {
-    "typo3/cms-core": "~6.2.0||~7.6.0||~8.7.0||~9.5.0||~10.4.0||dev-master"
+    "typo3/cms-core": "~6.2.0||~7.6.0||~8.7.0||~9.5.0||~10.4.0||~11.3.0||dev-master"
   },
   "replace": {
     "typo3-ter/dp_cookieconsent": "self.version"


### PR DESCRIPTION
If TYPO3 v11 is installed via concrete version constraint (e.g. typo3/cms-core: ^11.3), the extension cannot be installed.