### PR TITLE
fixed popup.text

### DIFF
--- a/Documentation/Configuration/Constants/Palette.rst
+++ b/Documentation/Configuration/Constants/Palette.rst
@@ -24,7 +24,7 @@ popup.background
 :aspect:`Default`
   rgba(0,0,0,.8)
 
-popup.background
+popup.text
 --------------------
 :aspect:`Description`
    Consent Text color


### PR DESCRIPTION
Mistakenly, above the explanation for popup.text was the heading popup.background