### PR TITLE
Change declaration of $descriptionLong in model Cookie

### DIFF
--- a/Classes/Domain/Model/Cookie.php
+++ b/Classes/Domain/Model/Cookie.php
@@ -59,7 +59,7 @@ class Cookie extends AbstractEntity
     /**
      * @var string
      */
-    protected $descriptionLong;
+    protected $descriptionLong = '';
 
 
     /**


### PR DESCRIPTION
Declare $descriptionLong with empty string, as its getter has a string return type. Fixes #138