### PR TITLE
make changes to run with TYPO3 v13

### DIFF
--- a/Classes/Controller/CookieController.php
+++ b/Classes/Controller/CookieController.php
@@ -15,7 +15,6 @@ use ArrayObject;
 use DirkPersky\DpCookieconsent\Domain\Repository\CookieRepository;
 use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Annotation\Inject;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -42,7 +41,7 @@ class CookieController extends ActionController
      */
     public function listAction(): ResponseInterface
     {
-        $cObj = $this->configurationManager->getContentObject();
+        $cObj = $this->request->getAttribute('currentContentObject');
         // parse Flexform
         $flexFormData = GeneralUtility::makeInstance(FlexFormService::class)->convertFlexFormContentToArray($cObj->data['pi_flexform']);
         // get Cookies

--- a/Classes/Controller/ScriptController.php
+++ b/Classes/Controller/ScriptController.php
@@ -23,7 +23,7 @@ class ScriptController extends ActionController{
      */
     public function listAction(): ResponseInterface
     {
-        $cObj = $this->configurationManager->getContentObject();
+        $cObj = $this->request->getAttribute('currentContentObject');
         // parse Flexform
         $flexFormData = GeneralUtility::makeInstance(FlexFormService::class)->convertFlexFormContentToArray($cObj->data['pi_flexform']);
         // remove duplicate Settings
@@ -42,7 +42,7 @@ class ScriptController extends ActionController{
      */
     public function showAction(): ResponseInterface
     {
-        $cObj = $this->configurationManager->getContentObject();
+        $cObj = $this->request->getAttribute('currentContentObject');
         // parse Flexform
         $flexFormData = GeneralUtility::makeInstance(FlexFormService::class)->convertFlexFormContentToArray($cObj->data['pi_flexform']);
         // remove duplicate Settings

--- a/Classes/Domain/Repository/CookieRepository.php
+++ b/Classes/Domain/Repository/CookieRepository.php
@@ -11,7 +11,6 @@
 
 namespace DirkPersky\DpCookieconsent\Domain\Repository;
 
-use TYPO3\CMS\Core\Database\QueryGenerator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
@@ -65,7 +64,7 @@ class CookieRepository extends Repository
             if ($permClause !== '') {
                 $queryBuilder->andWhere(QueryHelper::stripLogicalOperatorPrefix($permClause));
             }
-            $statement = $queryBuilder->execute();
+            $statement = $queryBuilder->executeQuery();
             while ($row = $statement->fetchAssociative()) {
                 if ($begin <= 0) {
                     $theList .= ',' . $row['uid'];

--- a/Configuration/FlexForms/ConsentAjax.xml
+++ b/Configuration/FlexForms/ConsentAjax.xml
@@ -1,105 +1,86 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <T3DataStructure>
-    <meta type="array">
-        <langDisable>1</langDisable>
-    </meta>
     <sheets>
-        <general>
-            <ROOT type="array">
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.title</sheetTitle>
-                </TCEforms>
-                <el type="array">
-                    <type type="array">
-                        <TCEforms type="array">
-                            <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_domain_model_cookie.category</label>
-                            <config type="array">
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items>
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_domain_model_cookie.category.1</numIndex>
-                                        <numIndex index="1">statistics</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_domain_model_cookie.category.2</numIndex>
-                                        <numIndex index="1">marketing</numIndex>
-                                    </numIndex>
-                                </items>
-                                <enableMultiSelectFilterTextfield>1</enableMultiSelectFilterTextfield>
-                            </config>
-                        </TCEforms>
+        <sDEF>
+            <ROOT>
+                <sheetTitle>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.title</sheetTitle>
+                <el>
+                    <type>
+                        <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_domain_model_cookie.category</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <items>
+                                <numIndex index="0">
+                                    <numIndex index="0">LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_domain_model_cookie.category.1</numIndex>
+                                    <numIndex index="1">statistics</numIndex>
+                                </numIndex>
+                                <numIndex index="1">
+                                    <numIndex index="0">LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_domain_model_cookie.category.2</numIndex>
+                                    <numIndex index="1">marketing</numIndex>
+                                </numIndex>
+                            </items>
+                            <enableMultiSelectFilterTextfield>1</enableMultiSelectFilterTextfield>
+                        </config>
                     </type>
 
-                    <consentscript type="array">
-                        <TCEforms type="array">
-                            <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.consentscript</label>
-                            <config type="array">
-                                <type>text</type>
-                                <cols>24</cols>
-                                <rows>8</rows>
-                                <renderType>t3editor</renderType>
-                                <format>html</format>
-                            </config>
-                        </TCEforms>
+                    <consentscript>
+                        <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.consentscript</label>
+                        <config>
+                            <type>text</type>
+                            <cols>24</cols>
+                            <rows>8</rows>
+                            <renderType>t3editor</renderType>
+                            <format>html</format>
+                        </config>
                     </consentscript>
 
-                    <records type="array">
-                        <TCEforms type="array">
-                            <label>LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:records</label>
-                            <config type="array">
-                                <type>group</type>
-                                <allowed>tt_content</allowed>
-                                <size>5</size>
-                                <maxitems>200</maxitems>
-                            </config>
-                        </TCEforms>
+                    <records>
+                        <label>LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:records</label>
+                        <config>
+                            <type>group</type>
+                            <allowed>tt_content</allowed>
+                            <size>5</size>
+                            <maxitems>200</maxitems>
+                        </config>
                     </records>
                 </el>
             </ROOT>
-        </general>
+        </sDEF>
         <consent>
-            <ROOT type="array">
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.consent</sheetTitle>
-                </TCEforms>
-                <el type="array">
-                    <notice type="array">
-                        <TCEforms type="array">
-                            <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.notice</label>
-                            <config type="array">
-                                <type>input</type>
-                                <size>250</size>
-                                <eval>trim</eval>
-                                <default></default>
-                                <placeholder>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang.xlf:media.notice</placeholder>
-                            </config>
-                        </TCEforms>
+            <ROOT>
+                <sheetTitle>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.consent</sheetTitle>
+                <el>
+                    <notice>
+                        <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.notice</label>
+                        <config>
+                            <type>input</type>
+                            <size>250</size>
+                            <eval>trim</eval>
+                            <default></default>
+                            <placeholder>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang.xlf:media.notice</placeholder>
+                        </config>
                     </notice>
-                    <description type="array">
-                        <TCEforms type="array">
-                            <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.desc</label>
-                            <config type="array">
-                                <type>text</type>
-                                <cols>250</cols>
-                                <rows>3</rows>
-                                <eval>trim</eval>
-                                <default></default>
-                                <placeholder>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang.xlf:media.desc</placeholder>
-                            </config>
-                        </TCEforms>
+                    <description>
+                        <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.desc</label>
+                        <config>
+                            <type>text</type>
+                            <cols>250</cols>
+                            <rows>3</rows>
+                            <eval>trim</eval>
+                            <default></default>
+                            <placeholder>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang.xlf:media.desc</placeholder>
+                        </config>
                     </description>
-                    <btn type="array">
-                        <TCEforms type="array">
-                            <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.btn</label>
-                            <config type="array">
-                                <type>input</type>
-                                <size>250</size>
-                                <eval>trim</eval>
-                                <default></default>
-                                <placeholder>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang.xlf:media.btn</placeholder>
-                            </config>
-                        </TCEforms>
+                    <btn>
+                        <label>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_ajax.btn</label>
+                        <config>
+                            <type>input</type>
+                            <size>250</size>
+                            <eval>trim</eval>
+                            <default></default>
+                            <placeholder>LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang.xlf:media.btn</placeholder>
+                        </config>
                     </btn>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/ConsentCookies.xml
+++ b/Configuration/FlexForms/ConsentCookies.xml
@@ -4,85 +4,79 @@
         <langDisable>1</langDisable>
     </meta>
     <sheets>
-        <general>
-            <ROOT type="array">
-                <TCEforms>
-                    <sheetTitle>
-                        LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_cookie.title
-                    </sheetTitle>
-                </TCEforms>
-                <el type="array">
+        <sDEF>
+            <ROOT>
+                <sheetTitle>
+                    LLL:EXT:dp_cookieconsent/Resources/Private/Language/locallang_db.xlf:tx_dpcookieconsent_cookie.title
+                </sheetTitle>
+                <el>
                     <!-- startingpoint -->
                     <settings.startingpoint>
-                        <TCEforms>
-                            <label>LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint
-                            </label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>db</internal_type>
-                                <allowed>pages</allowed>
-                                <size>3</size>
-                                <maxitems>50</maxitems>
-                                <minitems>0</minitems>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint
+                        </label>
+                        <config>
+                            <type>group</type>
+                            <internal_type>db</internal_type>
+                            <allowed>pages</allowed>
+                            <size>3</size>
+                            <maxitems>50</maxitems>
+                            <minitems>0</minitems>
+                        </config>
                     </settings.startingpoint>
                     <!-- recursive -->
                     <settings.recursive>
-                        <TCEforms>
-                            <label>LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.recursive</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items type="array">
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.recursive.I.inherit
-                                        </numIndex>
-                                        <numIndex index="1"></numIndex>
+                        <label>LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.recursive</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <items type="array">
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.recursive.I.inherit
                                     </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.0
-                                        </numIndex>
-                                        <numIndex index="1">0</numIndex>
+                                    <numIndex index="1"></numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.0
                                     </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.1
-                                        </numIndex>
-                                        <numIndex index="1">1</numIndex>
+                                    <numIndex index="1">0</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.1
                                     </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.2
-                                        </numIndex>
-                                        <numIndex index="1">2</numIndex>
+                                    <numIndex index="1">1</numIndex>
+                                </numIndex>
+                                <numIndex index="4" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.2
                                     </numIndex>
-                                    <numIndex index="5" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.3
-                                        </numIndex>
-                                        <numIndex index="1">3</numIndex>
+                                    <numIndex index="1">2</numIndex>
+                                </numIndex>
+                                <numIndex index="5" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.3
                                     </numIndex>
-                                    <numIndex index="6" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.4
-                                        </numIndex>
-                                        <numIndex index="1">4</numIndex>
+                                    <numIndex index="1">3</numIndex>
+                                </numIndex>
+                                <numIndex index="6" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.4
                                     </numIndex>
-                                    <numIndex index="7" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.5
-                                        </numIndex>
-                                        <numIndex index="1">250</numIndex>
+                                    <numIndex index="1">4</numIndex>
+                                </numIndex>
+                                <numIndex index="7" type="array">
+                                    <numIndex index="0">
+                                        LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.5
                                     </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                                    <numIndex index="1">250</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </settings.recursive>
                 </el>
             </ROOT>
-        </general>
+        </sDEF>
     </sheets>
 </T3DataStructure>

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -141,4 +141,6 @@ page {
 # Remove Original Google Tag-Manager & Piwiki from CS_SEO
 page.jsInline.654 >
 
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:dp_cookieconsent/Configuration/TypoScript/Tracking/googleTagManager.typoscript">
+[{$plugin.tx_cookieconsent.settings.tracking.googleTagManager.id} != ""]
+@import 'EXT:dp_cookieconsent/Configuration/TypoScript/Tracking/googleTagManager.typoscript'
+[END]

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "AGPL-3.0-or-later"
   ],
   "require": {
-    "typo3/cms-core": "^10.4.0||^11.5.0||^12.4.0||dev-master"
+    "typo3/cms-core": "^10.4.0||^11.5.0||^12.4.0||^13.4.0||dev-master"
   },
   "replace": {
     "typo3-ter/dp_cookieconsent": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,11 +19,11 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'infoy@dp-wired.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.4.99'
+            'typo3' => '11.5.0-13.4.99'
         ],
         'conflicts' => [],
         'suggests' => [],
     ],
     'state' => 'beta', // stable
-    'version' => '12.2.6'
+    'version' => '13.0.0'
 ];


### PR DESCRIPTION
I had made some changes to run with TYPO3 v13. Mostly minor changes to get rid of some deprecated code. The `/Classes/Middleware/PlainRenderingMiddleware.php` needed some more attention to move away from `$GLOBALS['TSFE']` that should not be used anymore and actually causes some errors. 

Hopefully you guys can have a look at this and get your Extension work with TYPO3 v13.

Closes #155

Thanks and best regards, Gianni