### PR TITLE
[BUGFIX] Repair googleTagManager.typoscript

### DIFF
--- a/Configuration/TypoScript/Tracking/googleTagManager.typoscript
+++ b/Configuration/TypoScript/Tracking/googleTagManager.typoscript
@@ -8,7 +8,7 @@ page.headerData.998 {
         }
 
         5 = COA
-        5 = {
+        5 {
             10 = TEXT
             10.value = https://www.googletagmanager.com
             10.wrap = <link rel="dns-prefetch" href="|" />


### PR DESCRIPTION
Remove superfluous "=" from configuration of page.headerData.998.20.5. Resolves #160 and #159